### PR TITLE
Create dthdtc and dthfl (fixes #12)

### DIFF
--- a/programs/sdtm/functions/death_funs.R
+++ b/programs/sdtm/functions/death_funs.R
@@ -1,11 +1,20 @@
 death_date <- function(.df, n = nrow(df), death_prob, end_date){
   start_date <- .df$RFSTDTC
 
-  NA
+  # Create death date per requirement (after RFSTDTC)
+  dthdtc <- rand_posixct(
+    start_date + lubridate::days(1),
+    start_date + lubridate::years(5)
+  )
+
+  # Randomly set ~50 % to NA to simulate non-deaths
+  dthdtc[sample(1:length(dthdtc), size = floor(length(dthdtc)/2))] <- NA
+
+  return(dthdtc)
 
 }
 
 death_flag <- function(.df, n = nrow(df)){
   dthdt <- .df$DTHDTC
-  "N"
+  return(dplyr::if_else(is.na(dthdt), "N", "Y"))
 }


### PR DESCRIPTION
DTHDTC and DTHFL need to be created.

DTHFL is "Y" when a death occurred, and "N" otherwise.

DTHDTC is the date time when death occurred. It should be after RFSTDTC, and not every patient should die.